### PR TITLE
Adding support for RN 0.50+

### DIFF
--- a/src/StorageController.react-native.js
+++ b/src/StorageController.react-native.js
@@ -17,7 +17,12 @@ try {
   // for React Native 0.43+
   AsyncStorage = require('react-native/Libraries/react-native/react-native-implementation').AsyncStorage;
 } catch (error) {
-  AsyncStorage = require('react-native/Libraries/react-native/react-native.js').AsyncStorage;
+  try {
+    AsyncStorage = require('react-native/Libraries/react-native/react-native.js').AsyncStorage;
+  } catch(error) {
+    // for React Native 0.50+
+    AsyncStorage = require('react-native/Libraries/Storage/AsyncStorage');
+  }
 }
 
 var StorageController = {


### PR DESCRIPTION
Added other try-catch to require the correct library for React Native 0.50+, as posted on [#496](https://github.com/parse-community/Parse-SDK-JS/issues/496)